### PR TITLE
Add :insert Result which returns the inserted primary key

### DIFF
--- a/pugsql/parser.py
+++ b/pugsql/parser.py
@@ -112,6 +112,8 @@ def _set_result(cpr, ktok):
         cpr['result'] = statement.Many()
     elif keyword == ':affected' or keyword == ':n':
         cpr['result'] = statement.Affected()
+    elif keyword == ':insert':
+        cpr['result'] = statement.Insert()
     elif keyword != ':raw':
         raise ParserError("unrecognized keyword '%s'" % keyword, ktok)
 

--- a/pugsql/statement.py
+++ b/pugsql/statement.py
@@ -41,6 +41,15 @@ class Affected(Result):
         return 'rowcount'
 
 
+class Insert(Result):
+    def transform(self, r):
+        return r.lastrowid
+
+    @property
+    def display_type(self):
+        return 'insert'
+
+
 class Raw(Result):
     def transform(self, r):
         return r

--- a/tests/sql/fixtures/insert_user.sql
+++ b/tests/sql/fixtures/insert_user.sql
@@ -1,0 +1,2 @@
+-- :name insert_user :insert
+insert into users(username) values (:username)

--- a/tests/test_pugsql.py
+++ b/tests/test_pugsql.py
@@ -29,6 +29,12 @@ class PugsqlTest(TestCase):
             1,
             self.fixtures.update_username(user_id=3, username='dottie'))
 
+    def test_insert(self):
+        pk = self.fixtures.insert_user(username='little_pug')
+        self.assertEqual(
+            {'username': 'little_pug', 'user_id': pk},
+            self.fixtures.user_for_id(user_id=pk))
+
     def test_bad_path(self):
         with pytest.raises(
                 ValueError,


### PR DESCRIPTION
This allows `insert` statements to quickly use the inserted primary key, this is useful when auto increment primary keys are used.

This feature is based on [this api](https://docs.sqlalchemy.org/en/13/core/connections.html#sqlalchemy.engine.ResultProxy.lastrowid).

The api docs for sqlalchemy say this:
> This is a DBAPI specific method and is only functional for those backends which support it, for statements where it is appropriate. It’s behavior is not consistent across backends.

I only tested this with sqlite (see tests/test_pugsql.py)