### PR TITLE
fix for AttributeError when initialized in other thread

### DIFF
--- a/pugsql/compiler.py
+++ b/pugsql/compiler.py
@@ -97,7 +97,7 @@ class Module(object):
             self._locals.session = None
 
     def _execute(self, clause, **params):
-        if self._locals.session:
+        if getattr(self._locals, 'session', None):
             return self._locals.session.execute(clause, params)
 
         if not self._engine:

--- a/pugsql/compiler.py
+++ b/pugsql/compiler.py
@@ -37,7 +37,6 @@ class Module(object):
         self._sessionmaker = None
 
         self._locals = threading.local()
-        self._locals.session = None
 
         for sqlfile in glob(os.path.join(self.sqlpath, '*sql')):
             with open(sqlfile, 'r') as f:
@@ -80,7 +79,7 @@ class Module(object):
         For more info, see here:
         https://docs.sqlalchemy.org/en/13/orm/session_transaction.html
         """
-        if not hasattr(self._locals, 'session') or not self._locals.session:
+        if not getattr(self._locals, 'session', None):
             if not self._sessionmaker:
                 raise NoConnectionError()
 

--- a/pugsql/compiler.py
+++ b/pugsql/compiler.py
@@ -80,7 +80,7 @@ class Module(object):
         For more info, see here:
         https://docs.sqlalchemy.org/en/13/orm/session_transaction.html
         """
-        if not self._locals.session:
+        if not hasattr(self._locals, 'session') or not self._locals.session:
             if not self._sessionmaker:
                 raise NoConnectionError()
 


### PR DESCRIPTION
## Bug report
I'm running `pugsql.module()` in flask's `app.before_first_request`, which I suspect means it runs in its own short-lived thread.

I get this traceback in the `Module.transaction` call (redacted):
```python
  File "**/auth.py", line **, in **
    with **.queries.transaction():
  File "/usr/lib/python3.6/contextlib.py", line 81, in __enter__
    return next(self.gen)
  File "**/.direnv/python-3.6.7/lib/python3.6/site-packages/pugsql/compiler.py", line 83, in transaction
    if not self._locals.session:
AttributeError: '_thread._local' object has no attribute 'session'
```

I think this is because self._locals.session gets initialized in the constructor i.e. only in one thread. I suspect that this would fail in the same way in any multithreaded program.
## Fix
`self._locals.session` -> `getattr(self._locals, 'session', None)`