### PR TITLE
Make modules iterable

### DIFF
--- a/pugsql/compiler.py
+++ b/pugsql/compiler.py
@@ -141,6 +141,9 @@ class Module(object):
         self._engine = None
         self._sessionmaker = None
 
+    def __iter__(self):
+        return iter(self._statements.values())
+
 
 __pdoc__['Module.sqlpath'] = (
     'The path that the `pugsql.compiler.Module` was loaded from.')

--- a/tests/test_pugsql.py
+++ b/tests/test_pugsql.py
@@ -156,3 +156,17 @@ class PugsqlTest(TestCase):
         self.assertEqual(
             { 'username': 'mcfunley', 'user_id': 1 },
             self.fixtures.user_for_id(user_id=1))
+
+    def test_iterable(self):
+        self.assertEqual(
+            {
+                self.fixtures.find_by_username_or_id,
+                self.fixtures.find_by_usernames,
+                self.fixtures.insert_user,
+                self.fixtures.search_users,
+                self.fixtures.update_username,
+                self.fixtures.user_for_id,
+                self.fixtures.username_for_id,
+            },
+            set(q for q in self.fixtures)
+        )


### PR DESCRIPTION
This implements #21, allowing

```python
for q in pugsql_module:
    data = q()
```