### PR TITLE
adding ability to interpolate identifiers

### DIFF
--- a/tests/sql/fixtures/identifier.sql
+++ b/tests/sql/fixtures/identifier.sql
@@ -1,0 +1,2 @@
+-- :name identifier :1
+select * from {{table_name}} limit 1

--- a/tests/sql/identifier.sql
+++ b/tests/sql/identifier.sql
@@ -1,0 +1,2 @@
+-- :name identifier :1
+select * from {{table_name}} limit 1

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -10,13 +10,13 @@ class BasicCompilerTest(TestCase):
 
     def test_sets_sqlpaths(self):
         m = compiler.Module('tests/sql')
-        self.assertEqual({'tests/sql',}, m.sqlpaths)
+        self.assertEqual({'tests/sql', }, m.sqlpaths)
 
     def test_function_redefinition(self):
         msg = (
-            'Error loading tests/sql/duplicate-name/foo.sql - a SQL function '
+            'Error loading tests/sql/duplicate-name/foo2.sql - a SQL function '
             'named foo was already defined in '
-            'tests/sql/duplicate-name/foo2.sql.')
+            'tests/sql/duplicate-name/foo.sql.')
         with pytest.raises(ValueError, match=msg):
             compiler.Module('tests/sql/duplicate-name')
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -19,6 +19,16 @@ class LexTest(TestCase):
             [l1, l2],
             lexer.lex(open('tests/sql/basic.sql', 'r').read(), ctx))
 
+    def test_basic_identifier(self):
+        l1 = lexer.Token('C', '-- :name identifier :1', at(1, 1))
+        l2 = lexer.Token(
+            'Q', 'select * from {{table_name}} limit 1',
+            at(2, 1))
+        self.assertEqual(
+            [l1, l2],
+            lexer.lex(open('tests/sql/identifier.sql', 'r').read(), ctx))
+
+
     def test_leading_comment_whitespace(self):
         l1 = lexer.Token('C', '-- :name username_for_id :1', at(1, 4))
         l2 = lexer.Token(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -18,6 +18,11 @@ class SqlTests(TestCase):
             parse('basic').sql,
             'select username from users where user_id = :user_id')
 
+    def test_identifier(self):
+        self.assertEqual(
+            parse('identifier').sql,
+            'select * from {{table_name}} limit 1')
+
     def test_extra_comments(self):
         self.assertEqual(
             parse('extra-comments').sql,

--- a/tests/test_pugsql.py
+++ b/tests/test_pugsql.py
@@ -27,6 +27,21 @@ class PugsqlTest(TestCase):
             { 'username': 'mcfunley', 'user_id': 1 },
             self.fixtures.user_for_id(user_id=1))
 
+    def test_set_identifier(self):
+        self.assertEqual(
+            { 'username': 'mcfunley', 'user_id': 1 },
+            self.fixtures.identifier(table_name='users'))
+
+    def test_set_identifier_invalid(self):
+        from pugsql.exceptions import InvalidArgumentError
+
+        with pytest.raises(
+                InvalidArgumentError,
+                match='Invalid SQL identifier table_name "users;"'):
+            self.assertEqual(
+                { 'username': 'mcfunley', 'user_id': 1 },
+                self.fixtures.identifier(table_name='users;'))
+
     def test_many(self):
         self.assertEqual(
             [{ 'username': 'oscar', 'user_id': 2 },],
@@ -170,6 +185,7 @@ class PugsqlTest(TestCase):
                 self.fixtures.find_by_username_or_id,
                 self.fixtures.find_by_usernames,
                 self.fixtures.insert_user,
+                self.fixtures.identifier,
                 self.fixtures.search_users,
                 self.fixtures.update_username,
                 self.fixtures.user_for_id,


### PR DESCRIPTION
Our system needs to interpolate identifiers, such as a schema name.

This change grabs the SQL string before it goes to SQLAlchemy and interpolates variables which are wrapped in {{ }}.
It also rejects any interpolation strings which are not valid SQL identifiers 
```
re.fullmatch(r'[a-zA-Z][0-9a-zA-Z_@$]+', pval)
```

