### PR TITLE
Correct method name for setting DB engine

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -90,7 +90,7 @@ The easiest way to connect to a database is to just call the `connect` method on
 queries.connect('postgresql://mcfunley@localhost/dbname')
 ```
 
-For more advanced uses, you can also pass a [SQLAlchemy Engine object](https://docs.sqlalchemy.org/en/13/core/connections.html#sqlalchemy.engine.Engine) to the `set_engine` method on the module instead.
+For more advanced uses, you can also pass a [SQLAlchemy Engine object](https://docs.sqlalchemy.org/en/13/core/connections.html#sqlalchemy.engine.Engine) to the `setengine` method on the module instead.
 
 ### Running Queries
 


### PR DESCRIPTION
pugsql modules don't have a `set_engine` method, but a `setengine` method. This edit updates the docs to reflect that.

```python
>>> import pugsql
>>> pugsql.__version__
'0.2.3'
>>> queries = pugsql.module('sql')
>>> queries.set_engine
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Module' object has no attribute 'set_engine'
>>> queries.setengine
<bound method Module.setengine of <pugsql.compiler.Module object at 0x102798358>>
```