### PR TITLE
This fixes #17

### DIFF
--- a/pugsql/parser.py
+++ b/pugsql/parser.py
@@ -36,7 +36,8 @@ def parse(pugsql, ctx=None):
     rest = stream[len(leading_comments):]
 
     cpr = _parse_comments(leading_comments)
-    sql = '\n'.join(cpr['unconsumed'] + [token.value for token in rest])
+    hdr = ['-- pugsql function %s in file %s' % (cpr['name'], ctx.sqlfile)]
+    sql = '\n'.join(hdr + cpr['unconsumed'] + [token.value for token in rest])
 
     return statement.Statement(
         name=cpr['name'],

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -27,6 +27,13 @@ class BasicCompilerTest(TestCase):
         with pytest.raises(ValueError, match=msg):
             compiler.Module('tests/sql/reserved')
 
+    def test_filename_in_sql_header_comment(self):
+        m = compiler.Module('tests/sql')
+        self.assertEqual(
+            m.username_for_id.sql,
+            '-- pugsql function username_for_id in file tests/sql/basic.sql\n'
+            'select username from users where user_id = :user_id')
+
     def test_multiple_statements_per_file(self):
         m = compiler.Module('tests/sql')
         self.assertEqual(m.basic_statement.name, 'basic_statement')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -16,11 +16,13 @@ class SqlTests(TestCase):
     def test_query(self):
         self.assertEqual(
             parse('basic').sql,
+            '-- pugsql function username_for_id in file <literal>\n'
             'select username from users where user_id = :user_id')
 
     def test_extra_comments(self):
         self.assertEqual(
             parse('extra-comments').sql,
+            '-- pugsql function foobar in file <literal>\n'
             '-- some extra commentary\nselect * from foo where bar = :bar')
 
 


### PR DESCRIPTION
I needed to fool the lint with the change in parser.py. The variable was first called `headers`, but then the lint complained about `./pugsql/parser.py:40:80: E501 line too long (82 > 79 characters)`. Then I made two lines of it, and then the lint said `W504 line break after binary operator`. Not sure how to fix this. I opted for abbrevating the variable name.

Also, with multiple statements it would be nice to add a line number within that file too. So for `multi-statement.sql` if you have the query for `multiline_statement` it would add " at line 4" to the informational comment. The compiler needs a change to provide the actual line number of the statement to the context.

Finally, to make the comment more readable, I would suggest look at python's stack trace format. Example, now there is:

    -- pugsql function multiline_statement in file tests/sql/multi-statement.sql at line 4

Compare to this:

    -- pugsql file "tests/sql/multi-statement.sql", line 4, function multiline_statement
